### PR TITLE
Adds hashing for the file name

### DIFF
--- a/zing/Gemfile
+++ b/zing/Gemfile
@@ -53,3 +53,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 # bootstrap gems
 gem 'bootstrap-sass', '~> 3.2.0'
 gem 'autoprefixer-rails'
+
+# hash function used for file names
+gem 'digest-murmurhash'

--- a/zing/Gemfile.lock
+++ b/zing/Gemfile.lock
@@ -55,6 +55,7 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
+    digest-murmurhash (1.1.1)
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.14)
@@ -177,6 +178,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   byebug
   coffee-rails (~> 4.2)
+  digest-murmurhash
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)

--- a/zing/app/models/file.rb
+++ b/zing/app/models/file.rb
@@ -1,3 +1,5 @@
+require 'digest/murmurhash'
+
 class File < ActiveRecord::Base
   has_one :file_data, dependent: :destroy
 
@@ -22,6 +24,16 @@ class File < ActiveRecord::Base
 
   def generate_file_url(file)
     # Create a unique url for file
+    puts "Generating download url #{file.original_filename}"
+    tmp_url = Digest::MurmurHash64a.hexdigest(file.original_filename + :id.to_s)
+    inc = 1
+    while File.exist?(file_url: tmp_url)
+      tmp_url = Digest::MurmurHash64a.hexdigest(file.original_filename +
+                                                (:id + inc).to_s)
+      inc += 1
+    end
+    puts " -- created url: #{tmp_url}"
+    tmp_url
   end
 
   def sanitize_filename(filename)

--- a/zing/db/migrate/20161106194120_make_url_unique.rb
+++ b/zing/db/migrate/20161106194120_make_url_unique.rb
@@ -1,0 +1,5 @@
+class MakeUrlUnique < ActiveRecord::Migration[5.0]
+  def change
+    add_index :files, :file_url, unique: true
+  end
+end

--- a/zing/db/schema.rb
+++ b/zing/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001185926) do
+ActiveRecord::Schema.define(version: 20161106194120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 20161001185926) do
     t.string   "file_url"
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
+    t.index ["file_url"], name: "index_files_on_file_url", unique: true, using: :btree
   end
 
   add_foreign_key "file_datas", "files"


### PR DESCRIPTION
Uses MurmurHashing to handle the hashing for file names.

Combines id and file name in order to generate a unqiue URL. If a collision exists, it changes the id to a different number and hashes it again until it finds a unique URL.